### PR TITLE
Fix Friend Request Sync Issues and Refactor Exam Completion Flow

### DIFF
--- a/backend/controller/quizzes/examController.js
+++ b/backend/controller/quizzes/examController.js
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import Exam from "../../models/quizzes/examModel.js";
 import Score from "../../models/quizzes/scoreModel.js";
+import Quiz from "../../models/quizzes/quizModel.js";
 
 export const getExam = async (req, res) => {
   try {
@@ -52,6 +53,106 @@ export const getExamFeedback = async (req, res) => {
     console.error(`Error fetching exam feedback: ${error.message}`);
     return res.status(500).json({
       message: `Error fetching exam feedback: ${error.message}`,
+    });
+  }
+};
+
+export const finishExam = async (req, res) => {
+  try {
+    const userId = req.user?._id;
+
+    const { quizId } = req.body;
+
+    const examFound = await Exam.findOne({ studentId: userId });
+
+    if (!examFound) {
+      return res.status(404).json({ message: "Exam not found" });
+    }
+
+    const examQuestions = examFound?.shuffledQuestions;
+
+    const examIsValid = examFound?.examFinish?.getTime() - Date.now();
+
+    if (!examIsValid) {
+      return res.status(400).json({ message: "Exam has expired" });
+    }
+
+    await Exam.findByIdAndUpdate(
+      examFound?._id,
+      { isInProgress: false },
+      { new: true }
+    );
+
+    const quizFound = await Quiz.findOne({ _id: quizId });
+
+    if (!quizFound) {
+      return res
+        .status(404)
+        .json({ message: "Cannot evaluate exam, no matching quiz found" });
+    }
+
+    let payloadScore = 0;
+
+    let userChoices = [];
+
+    for (let i = 0; i < quizFound.questions.length; i++) {
+      const q = quizFound.questions[i];
+
+      if (q.answer === examFound.answers[i]) {
+        payloadScore += 1;
+      }
+
+      userChoices[i] = {
+        userAnswer: examFound?.answers?.[i],
+        correctAnswer: q.answer,
+      };
+    }
+
+    const scoreFound = await Score.findOne({
+      user: userId,
+      quiz: quizFound?._id,
+    });
+
+    let scorePayload;
+
+    if (scoreFound) {
+      const updatedScore = await Score.findByIdAndUpdate(
+        scoreFound?._id,
+        {
+          $set: {
+            "examFeedback.userChoices": userChoices,
+            "examFeedback.randomizedQuestions": examQuestions,
+            highScore: Math.max(scoreFound.highScore, payloadScore),
+          },
+        },
+        { new: true }
+      );
+
+      scorePayload = updatedScore;
+    } else {
+      const newScore = new Score({
+        user: userId,
+        quiz: quizFound?._id,
+        examFeedback: {
+          userChoices,
+          randomizedQuestions: examQuestions,
+        },
+        highScore: payloadScore,
+      });
+
+      const updatedScore = await newScore.save();
+      scorePayload = updatedScore;
+    }
+
+    const examPayload = { examId: examFound?._id, scorePayload };
+
+    await Exam.findByIdAndDelete({ _id: examFound?._id });
+
+    res.status(200).json(examPayload);
+  } catch (error) {
+    console.error(`Error fetching exam feedback: ${error.message}`);
+    return res.status(500).json({
+      message: `Error finishing exam: ${error.message}`,
     });
   }
 };

--- a/backend/controller/socket/handleSocial.js
+++ b/backend/controller/socket/handleSocial.js
@@ -72,8 +72,8 @@ const handleSocialEvents = (context) => {
 
       if (userResponse === "declined") {
         const foundRequest = await Friend.findOne({
-          sender: senderId,
-          receiver: receiverId,
+          sender: receiverId,
+          receiver: senderId,
           status: "pending",
         });
 
@@ -91,14 +91,14 @@ const handleSocialEvents = (context) => {
 
         context.emitEvent("receiver", "friend request declined", {
           _id: payloadId,
-          receiverId: senderId,
+          receiverId,
         });
 
         return;
       }
 
       const friendRequest = await Friend.findOneAndUpdate(
-        { sender: senderId, receiver: receiverId, status: "pending" },
+        { sender: receiverId, receiver: senderId, status: "pending" },
         { status: userResponse },
         { new: true }
       );
@@ -110,14 +110,14 @@ const handleSocialEvents = (context) => {
       context.emitEvent("sender", "friend request accepted", {
         _id: friendRequest?._id,
         status: userResponse,
-        receiverId: senderId,
-        senderId: receiverId,
+        receiverId,
+        senderId,
       });
 
       context.emitEvent("receiver", "friend request accepted", {
         _id: friendRequest?._id,
-        senderId: receiverId,
-        receiverId: senderId,
+        senderId,
+        receiverId,
         status: userResponse,
       });
     } catch (error) {

--- a/backend/controller/socket/helpers/socket.exam.js
+++ b/backend/controller/socket/helpers/socket.exam.js
@@ -1,6 +1,5 @@
 import Exam from "../../../models/quizzes/examModel.js";
 import Quiz from "../../../models/quizzes/quizModel.js";
-import Score from "../../../models/quizzes/scoreModel.js";
 import Classroom from "../../../models/classrooms/classroomModel.js";
 
 export const createExam = async (context, data) => {
@@ -105,105 +104,6 @@ export const updateExam = async (context, data) => {
 
     context.emitEvent("sender", "error", {
       message: `Error updating exam ${data?.receiverId}:  ${error.message}`,
-    });
-  }
-};
-
-export const finishExam = async (context, data) => {
-  try {
-    const { senderId, receiverId } = data;
-
-    const examFound = await Exam.findOne({ studentId: senderId });
-
-    if (!examFound) {
-      throw new Error("Exam not found");
-    }
-
-    const examQuestions = examFound?.shuffledQuestions;
-
-    const examIsValid = examFound?.examFinish?.getTime() - Date.now();
-
-    if (!examIsValid) {
-      throw new Error("Exam has expired");
-    }
-
-    await Exam.findByIdAndUpdate(
-      examFound?._id,
-      { isInProgress: false },
-      { new: true }
-    );
-
-    const quizFound = await Quiz.findOne({ quizId: receiverId });
-
-    if (!quizFound) {
-      throw new Error("Cannot evaluate exam, no matching quiz found");
-    }
-
-    let payloadScore = 0;
-
-    let userChoices = [];
-
-    for (let i = 0; i < quizFound.questions.length; i++) {
-      const q = quizFound.questions[i];
-
-      if (q.answer === examFound.answers[i]) {
-        payloadScore += 1;
-      }
-
-      userChoices[i] = {
-        userAnswer: examFound?.answers?.[i],
-        correctAnswer: q.answer,
-      };
-    }
-
-    const scoreFound = await Score.findOne({
-      user: senderId,
-      quiz: quizFound?._id,
-    });
-
-    let scorePayload;
-
-    if (scoreFound) {
-      const updatedScore = await Score.findByIdAndUpdate(
-        scoreFound?._id,
-        {
-          $set: {
-            "examFeedback.userChoices": userChoices,
-            "examFeedback.randomizedQuestions": examQuestions,
-            highScore: Math.max(scoreFound.highScore, payloadScore),
-          },
-        },
-        { new: true }
-      );
-
-      scorePayload = updatedScore;
-    } else {
-      const newScore = new Score({
-        user: senderId,
-        quiz: quizFound?._id,
-        examFeedback: {
-          userChoices,
-          randomizedQuestions: examQuestions,
-        },
-        highScore: payloadScore,
-      });
-
-      const updatedScore = await newScore.save();
-      scorePayload = updatedScore;
-    }
-
-    const examPayload = { examId: examFound?._id, scorePayload };
-
-    await Exam.findByIdAndDelete({ _id: examFound?._id });
-
-    context.emitEvent("sender", "exam finished", examPayload);
-  } catch (error) {
-    console.error(
-      `Error finishing exam ${data?.receiverId}:  ${error.message}`
-    );
-
-    context.emitEvent("sender", "error", {
-      message: `Error finishing exam ${data?.receiverId}:  ${error.message}`,
     });
   }
 };

--- a/backend/controller/socket/helpers/socket.notification.js
+++ b/backend/controller/socket/helpers/socket.notification.js
@@ -118,7 +118,8 @@ export const handleNewNotification = async (context, data) => {
 
     context.emitEvent("receiver", "notification received", {
       savedNotification,
-      receiverId,
+      receiverId:
+        notificationName === "friend request accepted" ? receiverId : senderId,
     });
   } catch (error) {
     console.error("Error generating new notification", error.message);

--- a/backend/routes/quizzes/examRoutes.js
+++ b/backend/routes/quizzes/examRoutes.js
@@ -4,9 +4,11 @@ const examRoutes = Router();
 import {
   getExam,
   getExamFeedback,
+  finishExam,
 } from "../../controller/quizzes/examController.js";
 import { protect } from "../../middleware/authMiddleware.js";
 
+examRoutes.post("/", protect, finishExam);
 examRoutes.get("/", protect, getExam);
 examRoutes.get("/feedback/:quizId", protect, getExamFeedback);
 

--- a/frontend/src/features/quizzes/exam/examService.js
+++ b/frontend/src/features/quizzes/exam/examService.js
@@ -61,10 +61,31 @@ const getExamFeedback = async (quizId, token) => {
   }
 };
 
+const finishExam = async (quizId, token) => {
+  try {
+    if (!token) {
+      throw new Error("User is not authenticated, no token");
+    }
+
+    const config = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
+    const response = await axios.post(API_URL, config, { quizId });
+
+    return response.data;
+  } catch (error) {
+    handleServiceError(error);
+  }
+};
+
 const examService = {
   createExam,
   getExam,
   getExamFeedback,
+  finishExam,
 };
 
 export default examService;

--- a/frontend/src/features/quizzes/exam/examSlice.js
+++ b/frontend/src/features/quizzes/exam/examSlice.js
@@ -9,6 +9,7 @@ const initialState = {
   errorMessage: "",
   examData: {},
   quizFeedback: {},
+  examFeedback: {},
 };
 
 export const getExam = createAsyncThunk("exam/get", async (_, thunkAPI) => {
@@ -120,6 +121,7 @@ export const examSlice = createSlice({
         state.isError = false;
         state.errorMessage = "";
         state.quizFeedback = action.payload?.scorePayload;
+        state.examFeedback = action.payload;
         if (state.examData?._id === action.payload?.examId) {
           state.examData = {};
         }

--- a/frontend/src/features/quizzes/exam/examSlice.js
+++ b/frontend/src/features/quizzes/exam/examSlice.js
@@ -38,6 +38,21 @@ export const getExamFeedback = createAsyncThunk(
   }
 );
 
+export const finishExam = createAsyncThunk(
+  "exam/finish",
+  async (quizId, thunkAPI) => {
+    try {
+      const token = thunkAPI.getState().auth.user.token;
+
+      const response = await examService.finishExam(quizId, token);
+
+      return response;
+    } catch (error) {
+      handleSliceError(error);
+    }
+  }
+);
+
 export const examSlice = createSlice({
   name: "exam",
   initialState,
@@ -49,12 +64,6 @@ export const examSlice = createSlice({
     updateExam: (state, action) => {
       if (state.examData._id === action.payload._id) {
         state.examData.answers = action.payload.answers;
-      }
-    },
-    finishExam: (state, action) => {
-      state.quizFeedback = action.payload?.scorePayload;
-      if (state.examData?._id === action.payload?.examId) {
-        state.examData = {};
       }
     },
   },
@@ -97,11 +106,33 @@ export const examSlice = createSlice({
         state.isSuccess = false;
         state.isError = true;
         state.errorMessage = action.payload;
+      })
+      .addCase(finishExam.pending, (state) => {
+        state.isLoading = true;
+        state.isSuccess = false;
+        state.isError = false;
+        state.errorMessage = "";
+      })
+      .addCase(finishExam.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.isSuccess = true;
+        state.isExamFinished = true;
+        state.isError = false;
+        state.errorMessage = "";
+        state.quizFeedback = action.payload?.scorePayload;
+        if (state.examData?._id === action.payload?.examId) {
+          state.examData = {};
+        }
+      })
+      .addCase(finishExam.rejected, (state, action) => {
+        state.isLoading = false;
+        state.isSuccess = false;
+        state.isError = true;
+        state.errorMessage = action.payload;
       });
   },
 });
 
-export const { resetExam, createExam, updateExam, finishExam } =
-  examSlice.actions;
+export const { resetExam, createExam, updateExam } = examSlice.actions;
 
 export default examSlice.reducer;

--- a/frontend/src/hooks/useSocial.js
+++ b/frontend/src/hooks/useSocial.js
@@ -48,8 +48,8 @@ const useSocial = (user, setUserInfo, setFriendshipStatus) => {
 
       if (data?.receiverId === user?._id) {
         const notificationData = {
-          senderId: data?.receiverId,
-          receiverId: data?.senderId,
+          senderId: data?.senderId,
+          receiverId: data?.receiverId,
           notificationName: "friend request accepted",
         };
 

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -78,8 +78,8 @@ function UserProfile() {
 
     try {
       const eventData = {
-        senderId: userId,
-        receiverId: user?._id,
+        senderId: user?._id,
+        receiverId: userId,
         userResponse: friendReqResponse === "accept" ? "accepted" : "declined",
       };
 


### PR DESCRIPTION
### **Summary**  
This update resolves real-time synchronization issues in friend request processing, ensures notifications provide correct sender/receiver data, and refactors the exam completion process by removing socket-based handling in favor of HTTP requests.  

### **Changes**  

#### **Friend Request & Notification Fixes**  
- Flipped `senderId` and `receiverId` values when assigning `sender` and `receiver` properties in the `process friend request` event in `handleSocial.js`.  
- Updated `receiverId` property in `handleNewNotification` in `socket.notification.js` to:  
  - Provide `receiverId` if the friend request was accepted.  
  - Provide `senderId` if the request was declined.  
- Changed `senderId` and `receiverId` assignments to `data?.senderId` and `data?.receiverId`, respectively, in `handleAcceptRequest` in `useSocial.js`.  
- Flipped `senderId` and `receiverId` values in the event data object in `handleProcessRequest` in `UserProfile.jsx`.  

**📌 Fix:** These changes ensure correct real-time synchronization for friend request processing and notification integrity by properly setting the sender and receiver target IDs for the `friend request processed` and `new notification` socket events.  

#### **Exam Completion Refactor**  
- Removed `Score` model integration and `finishExam` handler function from `socket.exam.js`.  
- Refactored `finishExam` to use HTTP request/response handling instead of socket events in `examController.js`.  
- Integrated `finishExam` into its respective API route in `examRoutes.js`.  
- Implemented a new service function, `finishExam`, in `examService.js` to handle `POST` requests with `config` and `quizId`, returning the response.  
- Created a new async thunk `finishExam` in `examSlice.js` to manage the response from the `finishExam` service function.  
- Implemented `pending`, `fulfilled`, and `rejected` states for the `finishExam` async thunk in `examSlice.js`.  
- Removed the redundant `finishExam` action from `examSlice.js`.  

#### **Exam Feedback & Notification Handling**  
- Added a new `examFeedback` state property in `examSlice.js`.  
- Updated `examFeedback` with the payload from the `finishExam` thunk when fulfilled.  
- Implemented local state `isProcessing` in `Exam.jsx`, extracting `examData` from the exam slice to:  
  - Emit a `new notification` event with exam feedback before navigating to the home page.  
- Removed logic for subscribing and unsubscribing from the `exam finished` socket event in `Exam.jsx`.  

### **Fixes**  
- This update **closes #<issue-number>**, ensuring:  
  - Friend request processing and notifications display the correct sender and receiver.  
  - The exam completion process is handled via HTTP requests instead of unreliable socket event emissions.  
  - Notifications are properly emitted with exam feedback.  

### **Testing**  
- Verified that friend request processing updates correctly for both sender and receiver in real time.  
- Confirmed that notifications display the correct sender/receiver information.  
- Exam finish tests are still pending.