### PR TITLE
 Implement User Profile Update with Avatar Support

### DIFF
--- a/backend/routes/users/userRoutes.js
+++ b/backend/routes/users/userRoutes.js
@@ -15,6 +15,6 @@ const upload = multer({ storage });
 
 userRouter.post("/", upload.single("avatar"), registerUser);
 userRouter.post("/login", loginUser);
-userRouter.put("/", protect, updateUser);
+userRouter.put("/", protect, upload.single("avatar"), updateUser);
 
 export default userRouter;

--- a/frontend/src/components/users/UserForm.jsx
+++ b/frontend/src/components/users/UserForm.jsx
@@ -41,6 +41,21 @@ function UserForm({ setIsEditing, userDetails }) {
   }, [userDetails]);
 
   /**
+   * Cleans up the object URL for avatar preview when the component unmounts or dependencies change.
+   *
+   * This hook revokes the URL created for the avatar preview to prevent memory leaks if the avatarPreview is a valid string URL.
+   *
+   * @returns {void} - Nothing is returned from this effect
+   */
+  useEffect(() => {
+    return () => {
+      if (avatarPreview && typeof formData.avatar === "string") {
+        URL.revokeObjectURL(avatarPreview);
+      }
+    };
+  }, [avatarPreview, formData.avatar]);
+
+  /**
    * handleChange - Handles form input changes, specifically for file and text input fields.
    *
    * - Prevents default form submission behavior (e.preventDefault).
@@ -394,6 +409,12 @@ function UserForm({ setIsEditing, userDetails }) {
             type="submit"
             onClick={handleSubmit}
             value="Save changes"
+            disabled={
+              Object.values(pendingChanges).length === 0 ||
+              Object.keys(pendingChanges).every(
+                (key) => pendingChanges[key] === userDetails[key]
+              )
+            }
           />
           <button
             type="button"

--- a/frontend/src/components/users/UserForm.jsx
+++ b/frontend/src/components/users/UserForm.jsx
@@ -1,0 +1,412 @@
+import { useState, useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { FaCircleUser } from "react-icons/fa6";
+import { MdFileUpload } from "react-icons/md";
+import { updateUser } from "../../features/auth/authSlice.js";
+import {
+  updateUserList,
+  updateFriendList,
+} from "../../features/friend/friendSlice.js";
+
+function UserForm({ setIsEditing, userDetails }) {
+  const [avatarPreview, setAvatarPreview] = useState(null);
+  const [formData, setFormData] = useState({
+    avatar: null,
+    name: null,
+    email: null,
+    password: null,
+    password2: null,
+  });
+  const [pendingChanges, setPendingChanges] = useState({
+    avatar: null,
+    name: null,
+    email: null,
+    password: null,
+    password2: null,
+  });
+  const [editInfo, setEditInfo] = useState({
+    avatar: false,
+    name: false,
+    email: false,
+    password: false,
+  });
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!userDetails) return;
+
+    setFormData(userDetails);
+    setAvatarPreview(userDetails.avatar);
+  }, [userDetails]);
+
+  /**
+   * handleChange - Handles form input changes, specifically for file and text input fields.
+   *
+   * - Prevents default form submission behavior (e.preventDefault).
+   * - Sets form data state with new value from the input.
+   * - Special handling for "avatar" input field (file upload).
+   *
+   * Important notes:
+   * 1. `setEditInfo` is called to prevent editing state from resetting when input is changed. This ensures the form data can persist as users make edits.
+   * 2. For file input (avatar), `e.target.value` is set to `null` after the value is set, so that the input can properly receive a new file if selected again (important for file inputs in HTML).
+   *
+   * @param {Object} e - The event object from the input field.
+   */
+  const handleChange = (e) => {
+    e.preventDefault();
+
+    const targetName = e.target.name;
+    const isAvatar = targetName === "avatar";
+
+    const value = isAvatar ? e.target.files[0] : e.target.value;
+
+    setFormData((prevState) => ({
+      ...prevState,
+      [targetName]: value,
+    }));
+
+    if (isAvatar) {
+      setPendingChanges((prevState) => ({
+        ...prevState,
+        [targetName]: value,
+      }));
+    }
+
+    if (isAvatar && value) {
+      setAvatarPreview(URL.createObjectURL(value));
+    }
+
+    setEditInfo((prev) => ({ ...prev, [targetName]: true }));
+
+    if (isAvatar) {
+      e.target.value = null;
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    try {
+      const userData = Object.entries(pendingChanges).reduce(
+        (acc, [key, value]) => {
+          if (key === "avatar") {
+            if (value?.name !== userDetails[key]?.name) {
+              acc[key] = value;
+            }
+            return acc;
+          }
+
+          if (userDetails[key] !== value) {
+            acc[key] = value;
+          }
+
+          return acc;
+        },
+        {}
+      );
+
+      dispatch(updateUser(userData)).then((res) => {
+        if (res.type === "auth/update/fulfilled") {
+          dispatch(updateFriendList(res.payload));
+          dispatch(updateUserList(res.payload));
+          setIsEditing(false);
+        }
+      });
+    } catch (error) {
+      console.error("Error submiting user data: ", error.message);
+    }
+  };
+
+  const handleEdit = (e) => {
+    setEditInfo((prevState) => ({ ...prevState, [e.target.name]: true }));
+    setFormData((prevState) => ({
+      ...prevState,
+      [e.target.name]: pendingChanges[e.target.name]
+        ? pendingChanges[e.target.name]
+        : userDetails[e.target.name],
+    }));
+  };
+
+  return (
+    <div>
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
+      >
+        <div className="avatar-wrapper">
+          {editInfo.avatar ? (
+            <>
+              {formData?.avatar ? (
+                <img
+                  src={avatarPreview}
+                  alt="new avatar preview"
+                  style={{
+                    width: "80px",
+                    height: "80px",
+                    borderRadius: "50%",
+                    objectFit: "cover",
+                  }}
+                />
+              ) : (
+                <FaCircleUser />
+              )}
+              <button
+                type="button"
+                name="avatar"
+                onClick={(e) => {
+                  setFormData((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: userDetails[e.target.name],
+                  }));
+                  setPendingChanges((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: userDetails[e.target.name],
+                  }));
+                  setEditInfo((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: false,
+                  }));
+                  setAvatarPreview(userDetails.avatar);
+                }}
+              >
+                Cancel
+              </button>
+            </>
+          ) : avatarPreview ? (
+            <img
+              src={avatarPreview}
+              alt="user avatar"
+              style={{
+                width: "80px",
+                height: "80px",
+                borderRadius: "50%",
+                objectFit: "cover",
+              }}
+            />
+          ) : (
+            <FaCircleUser />
+          )}
+
+          <label className="upload-button">
+            <input
+              type="file"
+              style={{ display: "none" }}
+              id="avatar"
+              name="avatar"
+              accept="image/png, image/jpeg"
+              autoComplete="off"
+              onChange={handleChange}
+            />
+            <MdFileUpload />
+          </label>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+          }}
+        >
+          {editInfo.name ? (
+            <>
+              <input
+                type="text"
+                name="name"
+                onChange={handleChange}
+                value={formData?.name || ""}
+              />
+              <button
+                name="name"
+                type="button"
+                onClick={(e) => {
+                  setPendingChanges((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: formData[e.target.name],
+                  }));
+                  setEditInfo((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: false,
+                  }));
+                }}
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                name="name"
+                onClick={(e) => {
+                  setFormData((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: userDetails[e.target.name],
+                  }));
+                  setEditInfo((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: false,
+                  }));
+                }}
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <p>
+                {pendingChanges?.name
+                  ? pendingChanges?.name
+                  : userDetails?.name}
+              </p>
+              <button name="name" type="button" onClick={handleEdit}>
+                Change Name
+              </button>
+            </>
+          )}
+
+          {editInfo?.email ? (
+            <>
+              <input
+                type="email"
+                name="email"
+                onChange={handleChange}
+                value={formData?.email || ""}
+              />
+              <button
+                name="email"
+                type="button"
+                onClick={(e) => {
+                  setPendingChanges((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: formData[e.target.name],
+                  }));
+                  setEditInfo((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: false,
+                  }));
+                }}
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                name="email"
+                onClick={(e) => {
+                  setFormData((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: userDetails[e.target.name],
+                  }));
+                  setEditInfo((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: false,
+                  }));
+                }}
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <p>
+                {pendingChanges?.email
+                  ? pendingChanges?.email
+                  : userDetails?.email}
+              </p>
+              <button name="email" type="button" onClick={handleEdit}>
+                Change Email
+              </button>
+            </>
+          )}
+
+          {editInfo?.password ? (
+            <>
+              <input
+                type="password"
+                name="password"
+                onChange={handleChange}
+                value={formData?.password || ""}
+                placeholder="new password"
+                minLength={8}
+              />
+
+              <input
+                type="password"
+                name="password2"
+                onChange={handleChange}
+                value={formData?.password2 || ""}
+                placeholder="confirm password"
+                minLength={8}
+              />
+              <button
+                name="password"
+                type="button"
+                onClick={(e) => {
+                  if (formData?.password !== formData?.password2) {
+                    throw new Error("Passwords must match");
+                  }
+
+                  if (formData?.password.length < 8) {
+                    throw new Error("Password must be at least 8 characters");
+                  }
+
+                  setPendingChanges((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: formData[e.target.name],
+                  }));
+
+                  setEditInfo((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: false,
+                  }));
+                }}
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                name="password"
+                onClick={(e) => {
+                  setFormData((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: "",
+                  }));
+                  setEditInfo((prevState) => ({
+                    ...prevState,
+                    [e.target.name]: false,
+                  }));
+                }}
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button type="button" name="password" onClick={handleEdit}>
+              Change Password
+            </button>
+          )}
+        </div>
+
+        <div>
+          <input
+            type="submit"
+            onClick={handleSubmit}
+            value="Save changes"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              setIsEditing(false);
+            }}
+          >
+            Go Back
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default UserForm;

--- a/frontend/src/features/auth/authService.js
+++ b/frontend/src/features/auth/authService.js
@@ -48,19 +48,37 @@ const updateUser = async (userData, token) => {
       },
     };
 
-    const response = await axios.put(`${API_URL}/`, userData, config);
+    let multiPartData;
+
+    if (userData.avatar) {
+      const formData = new FormData();
+      formData.append("avatar", userData.avatar);
+      Object.entries(userData).forEach(([key, value]) => {
+        if (key !== "avatar") formData.append(key, value);
+      });
+
+      multiPartData = formData;
+    }
+
+    const response = await axios.put(
+      `${API_URL}/`,
+      userData.avatar ? multiPartData : userData,
+      config
+    );
 
     if (!response.data) {
       throw new Error("No response data received");
     }
-
     const updatedUser = { ...response.data, token };
 
-    localStorage.setItem("user", JSON.stringify(updatedUser));
+    if (!updatedUser || !updatedUser._id) {
+      throw new Error("Invalid user data received from server");
+    }
 
+    localStorage.setItem("user", JSON.stringify(updatedUser));
     return updatedUser;
   } catch (error) {
-    console.error(error.message);
+    console.error("Error updating user: ", error.message);
   }
 };
 

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -10,8 +10,11 @@ import {
 import socketEventManager from "../features/socket/socket.eventManager.js";
 import { FaCircleUser } from "react-icons/fa6";
 
+import UserForm from "../components/users/UserForm.jsx";
+
 function UserProfile() {
   const [userInfo, setUserInfo] = useState(null);
+  const [isEditing, setIsEditing] = useState(false);
   const [friendshipStatus, setFriendshipStatus] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -162,6 +165,15 @@ function UserProfile() {
 
   return isLoading ? (
     <p>Loading,please wait...</p>
+  ) : isEditing ? (
+    <UserForm
+      setIsEditing={setIsEditing}
+      userDetails={{
+        avatar: user?.avatar,
+        email: user?.email,
+        name: user?.name,
+      }}
+    />
   ) : (
     <div>
       <div className="avatar-wrapper">
@@ -180,7 +192,7 @@ function UserProfile() {
           <FaCircleUser />
         )}
       </div>
-      <h1>{userInfo.name}</h1>
+      <h1>{userInfo?.name}</h1>
       {String(user?._id) !== String(userId) && (
         <>
           {friendshipStatus === "pending" &&
@@ -316,8 +328,8 @@ function UserProfile() {
                         : friend?.senderName}
                     </p>
                   </div>
-                );
-              })}
+                ) : null
+              )}
             </div>
           ) : (
             <p>Friend list is empty</p>


### PR DESCRIPTION
## Summary

This pull request introduces robust functionality for updating user profile information, including avatar image support, improved backend validation, and responsive UI elements. It enhances both frontend and backend systems for more reliable and user-friendly profile editing.

---

### `userController.js`
- Access `avatar` from `req.file?.path` and other fields from `req.body`.
- Dynamically build the `updateFields` object to allow storing and deleting fields with `null` values.
- Validate uniqueness of the `email` field before updating a user.
- Exclude `password` and `__v` fields from the final update payload.

### `authService.js`
- Use `FormData` to append `userData` when uploading an avatar.
- Conditionally send `FormData` or JSON based on the presence of an avatar.
- Add validation to ensure server response data is valid before storing in `localStorage`.
- Improve error clarity by adding descriptive strings to `console.error` messages.

### `userRoutes.js`
- Add `multer` middleware to the API endpoint for handling avatar uploads.

### `UserForm.jsx`
- Integrate `useState` and `useEffect` for managing form state, avatar preview, and edit mode toggling.
- Populate form fields and avatar preview when component mounts or `userDetails` prop changes.
- Use `useDispatch` with `updateUserList` and `updateFriendList` actions to sync updated data with global state.
- Implement `handleChange` for conditionally handling text and file inputs.
- Implement `handleSubmit` to dispatch updates and validate pending changes.
- Add `cancel` functionality to revert unsaved changes and exit edit mode.
- Render form elements and buttons for user interaction.
- Clean up object URLs for avatar preview on unmount or dependency change.
- Disable the submit button if no changes are made.

### `UserProfile.jsx`
- Integrate the new `UserForm` component.
- Conditionally render the friend list only when viewing the authenticated user's profile.