### PR TITLE
Enhance control over connection status and user chat presence 

### DIFF
--- a/backend/controller/socket/handleSocketLifecycle.js
+++ b/backend/controller/socket/handleSocketLifecycle.js
@@ -12,7 +12,7 @@ import handleErrorEvents from "./helpers/socket.errorController.js";
 import { handleConnectionStatus } from "./helpers/socket.userPresence.js";
 
 const handleSocketLifeCycle = (io) => {
-  io.on("connection", (socket) => {
+  io.on("connection", async (socket) => {
     console.log(`New connection: Socket ID ${socket.id}`);
 
     const userId = socket?.user?.id;
@@ -25,8 +25,6 @@ const handleSocketLifeCycle = (io) => {
 
     const context = createSocketContext(socket, io);
 
-    handleConnectionStatus(context, { userId, isOnline: true });
-
     handleMessages(context);
     handleNotificationEvents(context);
     handleSocialEvents(context);
@@ -34,8 +32,10 @@ const handleSocketLifeCycle = (io) => {
     handleExamEvents(context);
     handleErrorEvents(socket);
 
-    socket.on("disconnect", () => {
-      handleConnectionStatus(context, { userId, isOnline: false });
+    await handleConnectionStatus(context, userId, "connected");
+
+    socket.on("disconnect", async () => {
+      await handleConnectionStatus(context, userId, "disconnected");
 
       console.log("User disconnected: ", userId);
       removeUserSocket(userId);

--- a/backend/controller/socket/helpers/socket.messages.js
+++ b/backend/controller/socket/helpers/socket.messages.js
@@ -186,15 +186,14 @@ export const handleChatStatus = async (context, data) => {
       throw new Error("Database update failure");
     }
 
-    await handleConnectionStatus(context, {
-      userId,
-      isOnline: updatedStatus?.online,
-    });
-
     context.emitEvent("sender", "chat status changed", {
       success: true,
       online: updatedStatus?.online,
     });
+
+    if (!updatedStatus.online) {
+      await handleConnectionStatus(context, userId, "offline");
+    }
   } catch (error) {
     console.error("Error turning off chat events: ", error.message);
     context.emitEvent("sender", "error", error.message);

--- a/backend/controller/socket/helpers/socket.userPresence.js
+++ b/backend/controller/socket/helpers/socket.userPresence.js
@@ -1,50 +1,95 @@
 import { getUserSocketMap } from "./socket.init.js";
 import Friend from "../../../models/users/friendModel.js";
+import User from "../../../models/users/userModel.js";
 
-export const handleConnectionStatus = async (context, userData) => {
-  const { userId, isOnline } = userData;
+export const handleConnectionStatus = async (
+  context,
+  userId,
+  connectionStatus
+) => {
+  try {
+    if (!userId) {
+      throw new Error("User id not found");
+    }
 
+    const userFound = await User.findOne({ _id: userId });
+
+    if (!userFound) {
+      throw new Error("User is not authorized");
+    }
+
+    const currentStatus = userFound?.online;
+
+    if (
+      connectionStatus === "connected" ||
+      connectionStatus === "reconnected"
+    ) {
+      if (!currentStatus) return;
+
+      const payloadList = await getOnlineList(userId);
+
+      context.emitEvent("sender", "user connected", { payloadList });
+
+      payloadList.forEach((onlineUser) => {
+        context.emitEvent("receiver", "friend connected", {
+          id: userId,
+          receiverId: onlineUser,
+        });
+      });
+    }
+
+    if (connectionStatus === "disconnected" || connectionStatus === "offline") {
+      if (!currentStatus && connectionStatus === "disconnected") return;
+
+      const payloadList = await getOnlineList(userId);
+
+      payloadList.forEach((onlineUser) => {
+        context.emitEvent("receiver", "friend disconnected", {
+          id: userId,
+          receiverId: onlineUser,
+        });
+      });
+    }
+  } catch (error) {
+    console.error("Error changing user connection status: ", error.message);
+    context.emitEvent("sender", "error", { message: error.message });
+  }
+};
+
+const getOnlineList = async (userId) => {
   const friendList = await Friend.find(
     {
       $or: [{ sender: userId }, { receiver: userId }],
     },
     "sender receiver"
-  );
-
-  const userMap = getUserSocketMap();
+  )
+    .populate("sender", "online")
+    .populate("receiver", "online");
 
   const onlineList = new Set();
 
   friendList.forEach((entry) => {
-    const senderId = entry.sender.toString();
-    const receiverId = entry.receiver.toString();
+    const senderId = entry.sender._id.toString();
+    const receiverId = entry.receiver._id.toString();
 
-    if (userMap.has(senderId) && senderId !== userId.toString()) {
+    const userSocketMap = getUserSocketMap();
+
+    if (
+      entry.sender.online &&
+      senderId.toString() !== userId.toString() &&
+      userSocketMap.has(senderId)
+    ) {
       onlineList.add(senderId);
     }
 
-    if (userMap.has(receiverId) && receiverId !== userId.toString()) {
+    if (
+      entry.receiver.online &&
+      receiverId.toString() !== userId.toString() &&
+      userSocketMap.has(receiverId)
+    ) {
       onlineList.add(receiverId);
     }
   });
 
-  const payloadList = Array.from(onlineList);
-
-  if (isOnline) {
-    context.emitEvent("sender", "user connected", { payloadList });
-
-    payloadList.forEach((onlineUser) => {
-      context.emitEvent("receiver", "friend connected", {
-        id: userId,
-        receiverId: onlineUser,
-      });
-    });
-  } else {
-    payloadList.forEach((onlineUser) => {
-      context.emitEvent("receiver", "friend disconnected", {
-        id: userId,
-        receiverId: onlineUser,
-      });
-    });
-  }
+  return Array.from(onlineList);
 };

--- a/backend/controller/socket/messageController.js
+++ b/backend/controller/socket/messageController.js
@@ -6,11 +6,12 @@ import {
   handleChatStatus,
 } from "./helpers/socket.messages.js";
 import validateFriendship from "../../middleware/socialMiddleware.js";
+import { handleConnectionStatus } from "./helpers/socket.userPresence.js";
 
 const handleMessages = (context) => {
-  context.socket.on("send message", (data) => {
+  context.socket.on("send message", async (data) => {
     try {
-      validateFriendship(data, async () => {
+      await validateFriendship(data, async () => {
         await sendMessage(context, data);
       });
     } catch (error) {
@@ -18,9 +19,9 @@ const handleMessages = (context) => {
     }
   });
 
-  context.socket.on("user typing", (data) => {
+  context.socket.on("user typing", async (data) => {
     try {
-      validateFriendship(data, () => {
+      await validateFriendship(data, () => {
         handleTyping(context, data);
       });
     } catch (error) {
@@ -30,7 +31,7 @@ const handleMessages = (context) => {
 
   context.socket.on("message read", async (data) => {
     try {
-      validateFriendship(data, async () => {
+      await validateFriendship(data, async () => {
         await handleMarkAsRead(context, data);
       });
     } catch (error) {
@@ -40,7 +41,7 @@ const handleMessages = (context) => {
 
   context.socket.on("open chat", async (data) => {
     try {
-      validateFriendship(data, async () => {
+      await validateFriendship(data, async () => {
         await handleChatOpen(context, data);
       });
     } catch (error) {
@@ -50,6 +51,15 @@ const handleMessages = (context) => {
 
   context.socket.on("change chat status", async (data) => {
     await handleChatStatus(context, data);
+  });
+
+  context.socket.on("reconnect chat", async (data) => {
+    try {
+      await handleConnectionStatus(context, data?.userId, "reconnected");
+    } catch (error) {
+      console.error("Error reconnecting chat: ", error.message);
+      context.emitEvent("sender", "error", error.message);
+    }
   });
 };
 

--- a/frontend/src/context/chatContext.js
+++ b/frontend/src/context/chatContext.js
@@ -115,12 +115,11 @@ const ChatProvider = ({ children }) => {
 
   const handleChatStatus = useCallback(
     (data) => {
+      if (!data?.success) return;
 
-      if (data?.success) {
-        dispatch(changeChatStatus(data?.online));
+      dispatch(changeChatStatus(data?.online));
 
-        chatStatus.current = data?.online ? "reconnected" : "disconnected";
-      }
+      chatStatus.current = data?.online ? "reconnected" : "disconnected";
     },
     [dispatch]
   );
@@ -224,11 +223,14 @@ const ChatProvider = ({ children }) => {
 
       dispatch(getMessages());
 
+      socketEventManager.handleEmitEvent("reconnect chat", {
+        userId: user?._id,
+      });
+
       chatStatus.current = null;
     }
 
     if (chatStatus.current === "disconnected") {
-      console.log("disconnecting chat events");
 
       subscriptions.forEach((event) => {
         socketEventManager.unsubscribe(event);


### PR DESCRIPTION
## Summary:
This PR improves socket lifecycle control by refactoring presence tracking logic, refining user connection status handling, and reducing redundant event emissions.

## Changes:
- **User Model & Presence Control**:
  - Integrate `User` schema model to track and reference the `online` property.
  - Replace `isOnline` with new `connectionStatus` parameter for detailed presence states.
  - Track `currentStatus` from the `User` document to prevent unnecessary socket events if chat is manually disabled.

- **Friend List Lookup Optimization**:
  - Refactor friend lookup logic into helper function `getOnlineList`.
  - Convert sender and receiver IDs to strings before comparison.
  - Ensure the `online` field is checked during online friend validation.

- **Socket Event Refactors**:
  - In `socket.messages.js`:
    - Conditionally call `handleConnectionStatus` only when switching from offline to online.
    - Pass `offline` status explicitly when user turns off chat presence.
    - Integrate `handleConnectionStatus` as a handler for new event `reconnect chat`.
    - Add guard clause in `handleChatStatus` to exit early on invalid update (`!data?.success`).
    - Emit `reconnect chat` event only when `chatStatus` is updated to `"reconnected"`.

- **Socket Lifecycle Updates**:
  - In `handleSocketLifecycle.js`:
    - Add `async` to `connection` callback.
    - Move `handleConnectionStatus` below socket event registration logic and call it with `connected` status.
    - Add `async/await` to `disconnect` callback and call `handleConnectionStatus` with `disconnected`.

- **Socket Event Handlers Enhancements**:
  - Add `async/await` to the following socket event handlers:
    - `send message`
    - `user typing`
    - `message read`
    - `open chat`

## Testing:
Manually tested full socket lifecycle: login, toggle chat status, reconnect, and disconnect behavior for accurate presence updates and no redundant emissions.
