### PR TITLE
Decouple notification generation logic

### DIFF
--- a/backend/controller/socket/handleSocial.js
+++ b/backend/controller/socket/handleSocial.js
@@ -1,5 +1,6 @@
 import Friend from "../../models/users/friendModel.js";
 import User from "../../models/users/userModel.js";
+import { handleNewNotification } from "./helpers/socket.notification.js";
 
 const handleSocialEvents = (context) => {
   context.socket.on("send friend request", async (data) => {
@@ -51,6 +52,14 @@ const handleSocialEvents = (context) => {
         "friend request received",
         friendRequestPayload
       );
+
+      const userData = {
+        senderId,
+        receiverId,
+        notificationName: "new friend request",
+      };
+
+      await handleNewNotification(context, userData);
     } catch (error) {
       console.error(error.message);
       context.socket.emit("error", error.message);
@@ -126,6 +135,14 @@ const handleSocialEvents = (context) => {
         "friend request accepted",
         friendRequestPayload
       );
+
+      const userData = {
+        senderId,
+        receiverId,
+        notificationName: "friend request accepted",
+      };
+
+      await handleNewNotification(context, userData);
     } catch (error) {
       console.error("Error processing friend request: ", error.message);
       context.emitEvent("sender", "error", { message: error.message });

--- a/backend/controller/socket/helpers/socket.exam.js
+++ b/backend/controller/socket/helpers/socket.exam.js
@@ -3,6 +3,7 @@ import Exam from "../../../models/quizzes/examModel.js";
 import Quiz from "../../../models/quizzes/quizModel.js";
 import Classroom from "../../../models/classrooms/classroomModel.js";
 import Score from "../../../models/quizzes/scoreModel.js";
+import { handleNewNotification } from "./socket.notification.js";
 
 export const createExam = async (context, data) => {
   try {
@@ -131,6 +132,15 @@ export const finishExam = async (context, data) => {
     }
 
     context.emitEvent("sender", "exam finished", examEndPayload.examPayload);
+
+    const notificationData = {
+      senderId: data?.senderId,
+      notificationName: "quiz graded",
+      quizScore: examEndPayload?.examPayload?.scorePayload?.latestScore,
+      quizId: examEndPayload?.examPayload?.scorePayload?.quiz,
+    };
+
+    await handleNewNotification(context, notificationData);
   } catch (error) {
     console.error(error.message);
   }

--- a/backend/controller/socket/helpers/socket.notification.js
+++ b/backend/controller/socket/helpers/socket.notification.js
@@ -119,7 +119,7 @@ export const handleNewNotification = async (context, data) => {
 
     context.emitEvent("receiver", "notification received", {
       savedNotification,
-      receiverId: notificationName === "quiz graded" ? senderId : receiverId,
+      receiverId,
     });
   } catch (error) {
     console.error("Error generating new notification", error.message);

--- a/frontend/src/hooks/useGlobalEvents.js
+++ b/frontend/src/hooks/useGlobalEvents.js
@@ -19,13 +19,6 @@ const useGlobalEvents = (currentLocation, user) => {
     (data) => {
       dispatch(finishExam(data));
 
-      socketEventManager.handleEmitEvent("new notification", {
-        senderId: data?.scorePayload?.user,
-        quizId: data?.scorePayload?.quiz,
-        quizScore: data?.scorePayload?.latestScore,
-        notificationName: "quiz graded",
-      });
-
       if (currentLocation.startsWith(`/exam/${data?.scorePayload?.quizId}`)) {
         navigate("/");
       }
@@ -36,12 +29,6 @@ const useGlobalEvents = (currentLocation, user) => {
   const handleIncomingRequest = useCallback(
     (data) => {
       dispatch(newFriendRequest(data));
-
-      socketEventManager.handleEmitEvent("new notification", {
-        senderId: data?.senderId,
-        receiverId: data?.receiverId,
-        notificationName: "new friend request",
-      });
     },
     [dispatch]
   );
@@ -63,19 +50,6 @@ const useGlobalEvents = (currentLocation, user) => {
   const handleAcceptRequest = useCallback(
     (data) => {
       dispatch(handleAccept(data));
-
-      if (data?.receiverId === user?._id) {
-        const notificationData = {
-          senderId: data?.senderId,
-          receiverId: data?.receiverId,
-          notificationName: "friend request accepted",
-        };
-
-        socketEventManager.handleEmitEvent(
-          "new notification",
-          notificationData
-        );
-      }
     },
     [dispatch, user?._id]
   );


### PR DESCRIPTION
## Summary:
This Pull Request decouples client-side notification emission logic by centralizing `new notification` socket event triggers in backend socket event handlers.

## Changes:
- **Backend Socket Event Integration**:
  - Integrated `handleNewNotification` in `handleSocial.js`:
    - Handles `send friend request` and `friend request accepted` socket callbacks.
  - Integrated `handleNewNotification` in `socket.exam.js`:
    - Handles `exam finished` socket callbacks to notify relevant users with exam feedback.

- **Client Cleanup**:
  - Removed `new notification` socket emissions from the following frontend functions in `useGlobalEvents.js`:
    - `handleFinishExam`
    - `handleIncomingRequest`
    - `handleAcceptRequest`

- **Notification Handler Simplification**:
  - Removed redundant `receiverId` evaluation logic in `handleNewNotification` in `socket.notification.js`.

## Testing:
Manually tested friend request, acceptance, and exam feedback flows to confirm `new notification` events are emitted correctly from the backend.
