### PR TITLE
Change classroom retrieval and state management

### DIFF
--- a/backend/controller/classroom/classroomController.js
+++ b/backend/controller/classroom/classroomController.js
@@ -25,7 +25,7 @@ export const joinClassroom = async (req, res) => {
     }
 
     classroom.students.push(userId);
-    await classroom.save();
+    const updatedClassroom = await classroom.save();
 
     await User.findByIdAndUpdate(
       userId,
@@ -35,7 +35,7 @@ export const joinClassroom = async (req, res) => {
 
     return res.status(200).json({
       message: "User joined classroom successfully",
-      classroom,
+      updatedClassroom,
     });
   } catch (error) {
     return res.status(500).json({
@@ -102,17 +102,17 @@ export const getAllClassrooms = async (req, res) => {
   }
 };
 
-export const getUserClassrooms = async (req, res) => {
+export const getUserClassroom = async (req, res) => {
   try {
     const user = req.user;
 
-    if (!user || !user._id) {
+    if (!user || !user?._id) {
       return res.status(403).json({ message: "User id is required" });
     }
 
-    const classrooms = await Classroom.find({ students: user._id });
+    const classroom = await Classroom.find({ students: user?._id });
 
-    return res.status(200).json(classrooms);
+    return res.status(200).json(classroom.length ? classroom[0] : null);
   } catch (error) {
     return res.status(500).json({
       message: error.message,

--- a/backend/routes/classrooms/classroomRoutes.js
+++ b/backend/routes/classrooms/classroomRoutes.js
@@ -6,12 +6,12 @@ import {
   joinClassroom,
   leaveClassroom,
   getAllClassrooms,
-  getUserClassrooms,
+  getUserClassroom,
 } from "../../controller/classroom/classroomController.js";
 
 classroomRoutes.post("/join/:classroomId", protect, joinClassroom);
 classroomRoutes.post("/leave/:classroomId", protect, leaveClassroom);
 classroomRoutes.get("/", protect, getAllClassrooms);
-classroomRoutes.get("/me", protect, getUserClassrooms);
+classroomRoutes.get("/me", protect, getUserClassroom);
 
 export default classroomRoutes;

--- a/frontend/src/components/classroom/Classroom.jsx
+++ b/frontend/src/components/classroom/Classroom.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import {
   getClassroomList,
+  getUserClassroom,
   joinClassroom,
   leaveClassroom,
   resetClassroom,
@@ -15,6 +16,7 @@ function Classroom() {
 
   const {
     classroomList = [],
+    userClassroom,
     isLoading,
     isError,
     errorMessage,
@@ -22,6 +24,7 @@ function Classroom() {
 
   useEffect(() => {
     dispatch(getClassroomList());
+    dispatch(getUserClassroom());
 
     return () => {
       dispatch(resetClassroom());
@@ -88,23 +91,31 @@ function Classroom() {
         ) : classroomList.length === 0 ? (
           <p>No classrooms available.</p>
         ) : (
-          <div className="clasroom__enroll__dropdown-items">
-            <span>Select a Classroom:</span>
-            <select
-              id="classroom-select"
-              value={selectedClassroom}
-              onChange={handleChange}
-            >
-              <option value="" disabled></option>
-              {classroomList.map((classroom) => (
-                <option
-                  key={`classroom-${classroom?._id}`}
-                  value={classroom?._id}
-                >
-                  {classroom?.name}
-                </option>
-              ))}
-            </select>
+          <div>
+            <span>
+              {userClassroom
+                ? `Current classroom: ${userClassroom?.name}`
+                : "User is not enrolled in classroom"}
+            </span>
+
+            <div className="clasroom__enroll__dropdown-items">
+              <span>Select a Classroom:</span>
+              <select
+                id="classroom-select"
+                value={selectedClassroom}
+                onChange={handleChange}
+              >
+                <option value="" disabled></option>
+                {classroomList.map((classroom) => (
+                  <option
+                    key={`classroom-${classroom?._id}`}
+                    value={classroom?._id}
+                  >
+                    {classroom?.name}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/features/classroom/classroomService.js
+++ b/frontend/src/features/classroom/classroomService.js
@@ -49,10 +49,24 @@ const getClassroomList = async (token) => {
   }
 };
 
+const getUserClassroom = async (token) => {
+  try {
+    const response = await axiosInstance.get(`${API_URL}/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    return response.data;
+  } catch (error) {
+    handleServiceError(error);
+    throw error;
+  }
+};
+
 const classroomService = {
   joinClassroom,
   leaveClassroom,
   getClassroomList,
+  getUserClassroom,
 };
 
 export default classroomService;

--- a/frontend/src/features/classroom/classroomSlice.js
+++ b/frontend/src/features/classroom/classroomSlice.js
@@ -8,6 +8,7 @@ const initialState = {
   isError: false,
   errorMessage: "",
   classroomList: [],
+  userClassroom: null,
 };
 
 export const joinClassroom = createAsyncThunk(
@@ -71,6 +72,24 @@ export const getClassroomList = createAsyncThunk(
   }
 );
 
+export const getUserClassroom = createAsyncThunk(
+  "classroom/getUserClassroom",
+  async (_, thunkAPI) => {
+    try {
+      const { token } = thunkAPI.getState().auth.user;
+      if (!token) {
+        throw new Error("Token not found");
+      }
+
+      const data = await classroomService.getUserClassroom(token);
+
+      return data;
+    } catch (error) {
+      handleSliceError(error);
+    }
+  }
+);
+
 const classroomSlice = createSlice({
   name: "classroom",
   initialState,
@@ -89,7 +108,7 @@ const classroomSlice = createSlice({
         state.isSuccess = true;
         state.isError = false;
         state.errorMessage = "";
-        state.classroomList.push(action.payload.classroom);
+        state.userClassroom = action.payload?.updatedClassroom;
       })
       .addCase(joinClassroom.rejected, (state, action) => {
         state.isLoading = false;
@@ -116,6 +135,25 @@ const classroomSlice = createSlice({
         state.isError = true;
         state.errorMessage =
           action.payload?.message || "Failed to load classrooms";
+      })
+      .addCase(getUserClassroom.pending, (state) => {
+        state.isLoading = true;
+        state.isError = false;
+        state.errorMessage = "";
+      })
+      .addCase(getUserClassroom.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.isSuccess = true;
+        state.isError = false;
+        state.errorMessage = "";
+        state.userClassroom = action.payload;
+      })
+      .addCase(getUserClassroom.rejected, (state, action) => {
+        state.isLoading = false;
+        state.isSuccess = false;
+        state.isError = true;
+        state.errorMessage =
+          action.payload?.message || "Failed to get user classroom";
       })
       .addCase(leaveClassroom.pending, (state) => {
         state.isLoading = true;


### PR DESCRIPTION
## Summary:
This Pull Request refactors classroom retrieval to target a single active classroom per user, updating backend logic, redux integration, and UI rendering to align with this constraint.

## Changes:
- **Classroom Controller**:
  - Store classroom update result in `updatedClassroom` and use it as response payload in `joinClassroom`.
  - Rename `getUserClassrooms` function to `getUserClassroom`.
  - Add optional chaining for `user._id` in `getUserClassroom`.
  - Return first classroom entry or `null` as payload in `getUserClassroom`.

- **Classroom Routes**:
  - Change all instances of `getUserClassrooms` to `getUserClassroom`.

- **Classroom Service**:
  - Implement and export `getUserClassroom` service function to send request, return response data, and handle errors.

- **Classroom Slice**:
  - Add new state property `userClassroom` with default `null`.
  - Implement new async thunk `getUserClassroom` with pending, fulfilled, and rejected cases.
  - Update `userClassroom` state on `joinClassroom.fulfilled` action.

- **UI Integration**:
  - Dispatch and subscribe to `getUserClassroom`.
  - Render `span` element showing enrolled classroom name or fallback message.
  - Add container `div` for user classroom display and enrollment select input.

## Testing:
Manual testing was performed to confirm expected classroom retrieval, state update, and UI rendering.
