### PR TITLE
 Improve Message Controllers and Extend Unit Test Suites 

### DIFF
--- a/backend/controller/socket/handlers/handleMessages.js
+++ b/backend/controller/socket/handlers/handleMessages.js
@@ -45,7 +45,7 @@ export const handleChatOpen = async (context, data) => {
     const response = await updateChatMessages(models, data);
 
     if (!response.success) {
-      throw new Error("Unable to update messages");
+      throw new Error(response.message || "Unable to update messages");
     }
 
     if (!response.newMessages) {

--- a/test/mocks/config/mockSocketModel.js
+++ b/test/mocks/config/mockSocketModel.js
@@ -165,7 +165,7 @@ export default class MockSocketModel {
     const updated = { ...items[index], ...updates };
     items[index] = updated;
 
-    return this.handleSelect(options.new ? updated : items[index]);
+    return this.handleChain(options.new ? updated : items[index]);
   }
 
   async findOneAndUpdate(query, updates, options = {}) {

--- a/test/unit/backend/socket/handleMessageUnit.test.js
+++ b/test/unit/backend/socket/handleMessageUnit.test.js
@@ -315,5 +315,52 @@ describe("socket message controllers", () => {
       expect(response.newMessages).to.equal(false);
       expect(response.message).to.equal("No unread messages");
     });
+
+    it("should return early, with a message `Missing models`", async () => {
+      const models = { Chat: undefined, Conversation: ConversationFactory };
+      const eventData = {
+        senderId: mockSender._id,
+        receiverId: mockReceiver._id,
+      };
+
+      try {
+        await updateChatMessages(models, eventData);
+      } catch (error) {
+        expect(error.message).to.equal("Missing models");
+      }
+    });
+
+    it("should return with a message `Chat not found`", async () => {
+      const models = { Chat: ChatFactory, Conversation: ConversationFactory };
+      const eventData = {
+        senderId: mockSender._id,
+        receiverId: "999",
+      };
+
+      const response = await updateChatMessages(models, eventData);
+      expect(response.success).to.equal(false);
+      expect(response.newMessages).to.equal(false);
+      expect(response.message).to.equal("Chat not found");
+    });
+
+    it("should return early, with a message `No chat messages`", async () => {
+      const models = { Chat: ChatFactory, Conversation: ConversationFactory };
+
+      const testUserId = "test user id";
+      ChatFactory.create({
+        participants: [mockSender._id, testUserId],
+        conversation: [],
+      });
+
+      const eventData = {
+        senderId: mockSender._id,
+        receiverId: testUserId,
+      };
+
+      const response = await updateChatMessages(models, eventData);
+      expect(response.success).to.equal(true);
+      expect(response.newMessages).to.equal(false);
+      expect(response.message).to.equal("No chat messages");
+    });
   });
 });

--- a/test/unit/backend/socket/handleMessageUnit.test.js
+++ b/test/unit/backend/socket/handleMessageUnit.test.js
@@ -93,12 +93,14 @@ class ConversationFactory extends MockSocketModel {
       );
 
       if (!itemsFound) {
-        return null;
+        return { matchedCount: 0, modifiedCount: 0 };
       }
 
       itemsFound.forEach((item) => {
         Object.assign(item, updates.$set);
       });
+
+      return { matchedCount: 1, modifiedCount: itemsFound.length };
     } catch (error) {
       const errorMessage = `Error updating documents: ${
         error.message || "Unknown error"
@@ -298,6 +300,20 @@ describe("socket message controllers", () => {
       const conversationStorage = ChatFactory.getStorage().conversations;
 
       conversationStorage.forEach((item) => expect(item.isRead).to.equal(true));
+    });
+
+    it("should return early, with a message `No unread messages`", async () => {
+      const models = { Chat: ChatFactory, Conversation: ConversationFactory };
+      const eventData = {
+        senderId: mockSender._id,
+        receiverId: mockReceiver._id,
+      };
+
+      const response = await updateChatMessages(models, eventData);
+
+      expect(response.success).to.equal(true);
+      expect(response.newMessages).to.equal(false);
+      expect(response.message).to.equal("No unread messages");
     });
   });
 });

--- a/test/unit/backend/socket/handleMessageUnit.test.js
+++ b/test/unit/backend/socket/handleMessageUnit.test.js
@@ -3,6 +3,7 @@ import MockSocketModel from "../../../mocks/config/mockSocketModel.js";
 import MockData from "../../../mocks/config/mockData.js";
 import {
   createMessage,
+  markMessageSeen,
   updateChatMessages,
 } from "../../../../backend/controller/socket/controllers/socket.messageControllers.js";
 
@@ -109,6 +110,10 @@ class ConversationFactory extends MockSocketModel {
       console.error(errorMessage);
       throw new Error(errorMessage);
     }
+  }
+
+  static async findByIdAndUpdate(id, updates, options = {}) {
+    return new this().findByIdAndUpdate(id, updates, options);
   }
 }
 
@@ -361,6 +366,33 @@ describe("socket message controllers", () => {
       expect(response.success).to.equal(true);
       expect(response.newMessages).to.equal(false);
       expect(response.message).to.equal("No chat messages");
+    });
+  });
+
+  describe("mark message as seen", () => {
+    it("should update new message `isRead` property to true and verify it", async () => {
+      const models = { Conversation: ConversationFactory };
+
+      const newMessage = {
+        senderId: mockSender._id,
+        receiverId: mockReceiver._id,
+        text: "mark message seen test message",
+        isRead: false,
+      };
+
+      const createdMessage = await ConversationFactory.create(newMessage);
+
+      const eventData = {
+        messageId: createdMessage?._id,
+      };
+
+      const response = await markMessageSeen(models, eventData);
+
+      expect(response._id).to.equal(createdMessage._id);
+      expect(response.senderId).to.equal(createdMessage.senderId);
+      expect(response.receiverId).to.equal(createdMessage.receiverId);
+      expect(response.text).to.equal(createdMessage.text);
+      expect(response.isRead).to.equal(true);
     });
   });
 });

--- a/test/unit/backend/socket/handleMessageUnit.test.js
+++ b/test/unit/backend/socket/handleMessageUnit.test.js
@@ -394,5 +394,33 @@ describe("socket message controllers", () => {
       expect(response.text).to.equal(createdMessage.text);
       expect(response.isRead).to.equal(true);
     });
+
+    it("should return `Missing models` error message", async () => {
+      const models = { Conversation: undefined };
+
+      const eventData = {
+        messageId: "test message id",
+      };
+
+      try {
+        await markMessageSeen(models, eventData);
+      } catch (error) {
+        expect(error.message).to.equal("Missing models");
+      }
+    });
+
+    it("should return `Invalid message id` error message", async () => {
+      const models = { Conversation: ConversationFactory };
+
+      const eventData = {
+        messageId: undefined,
+      };
+
+      try {
+        await markMessageSeen(models, eventData);
+      } catch (error) {
+        expect(error.message).to.equal("Invalid message id");
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

This pull request extends the message controllers by introducing support for updating chat messages and marking messages as seen. It adds corresponding factory methods, improves response handling in controllers, and expands unit test coverage to include success, edge case, and error scenarios.

## Changes

### socket.messageControllers.js

* Added new response handling with a `let response` variable to assign payloads based on query results in `updateChatMessages`.
* Removed fallback value of empty array for `chatFound` queries.
* Added early return clause for invalid chat queries in `updateChatMessages`.

### mockSocketModel.js

* Updated `findByIdAndUpdate` response formation to use `handleChain` instead of `handleSelect`.

### ConversationFactory

* Added new static method `updateMany` to handle modifying `isRead` property for conversations used in `updateChatMessages`.
* Added static `findByIdAndUpdate` method to support `markMessageSeen` operations.
* Modified `updateMany` method to return an object containing `matchedCount` and `modifiedCount`.

### handleMessageUnit.test.js

* Integrated `updateChatMessages` controller and added test cases for successful API calls on the receiver side.
* Added scenarios for no unread messages during `updateChatMessages` calls.
* Implemented test cases for missing models, chat not found, and empty conversation scenarios.
* Integrated `markMessageSeen` controller and added test cases for successful calls.
* Added error test cases for `markMessageSeen`, including missing models and invalid message IDs.
